### PR TITLE
AddLoadingBar No longer breaks builderchains

### DIFF
--- a/Toolbelt.Blazor.LoadingBar/LoadingBarExtension.cs
+++ b/Toolbelt.Blazor.LoadingBar/LoadingBarExtension.cs
@@ -16,9 +16,9 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
         ///  Adds a LoadingBar service to the specified Microsoft.Extensions.DependencyInjection.IServiceCollection.
         /// </summary>
         /// <param name="services">The Microsoft.Extensions.DependencyInjection.IServiceCollection to add the service to.</param>
-        public static void AddLoadingBar(this IServiceCollection services)
+        public static IServiceCollection AddLoadingBar(this IServiceCollection services)
         {
-            services.AddLoadingBar(configure: null);
+            return services.AddLoadingBar(configure: null);
         }
 
         /// <summary>
@@ -26,7 +26,7 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
         /// </summary>
         /// <param name="services">The Microsoft.Extensions.DependencyInjection.IServiceCollection to add the service to.</param>
         /// <param name="configure"></param>
-        public static void AddLoadingBar(this IServiceCollection services, Action<LoadingBarOptions>? configure)
+        public static IServiceCollection AddLoadingBar(this IServiceCollection services, Action<LoadingBarOptions>? configure)
         {
             services.AddHttpClientInterceptor();
             services.TryAddSingleton(sp =>
@@ -37,6 +37,7 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
                 configure?.Invoke(loadingBar.Options);
                 return loadingBar;
             });
+            return services;
         }
 
         private static bool Installed;

--- a/Toolbelt.Blazor.LoadingBar/LoadingBarExtension.cs
+++ b/Toolbelt.Blazor.LoadingBar/LoadingBarExtension.cs
@@ -46,7 +46,7 @@ namespace Toolbelt.Blazor.Extensions.DependencyInjection
         ///  Installs a LoadingBar service to the runtime hosting environment.
         /// </summary>
         /// <param name="host">The Microsoft.AspNetCore.Blazor.Hosting.WebAssemblyHost.</param>
-        [Obsolete("Use \"builder.UserLoadingBar();\" instead.")]
+        [Obsolete("Use \"builder.UseLoadingBar();\" instead.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public static WebAssemblyHost UseLoadingBar(this WebAssemblyHost host)
         {


### PR DESCRIPTION
currently ``.AddLoadingBar()`` returns void which breaks builder chains like 
```cs
 return collection
            .AddScoped<IAuthenticationService, AuthenticationService>()
            .AddScoped<IHttpService, HttpService>()
            .AddSingleton<IThemeService, ThemeService>();
```